### PR TITLE
Add Windows support for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 /lib
 # stockfish installation
 /stockfish
+/stockfish-win

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,14 +1,17 @@
 import Stockfish from "../index";
+import * as os from "os";
+import { getNullDevicePath, getStockfishBinPath } from "../test-utils";
 
 // TODO: mock out the child process for better testing (particularly with options)
 
 const STARTPOS = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 const E4 = "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1";
 
+const platform = os.platform();
 let engine: Stockfish;
 
 beforeEach(() => {
-  engine = new Stockfish("./stockfish/engine");
+  engine = new Stockfish(getStockfishBinPath(platform));
 });
 
 afterEach(async () => {
@@ -22,8 +25,8 @@ describe("Stockfish", () => {
   });
   it("supports options", async () => {
     // not sure of a good way to test this that wouldn't be flaky
-    const anotherEngine = new Stockfish("./stockfish/engine", {
-      "Debug Log File": "/dev/null",
+    const anotherEngine = new Stockfish(getStockfishBinPath(platform), {
+      "Debug Log File": getNullDevicePath(platform),
       Contempt: -20,
       "Analysis Contempt": "Both",
       Threads: 1,
@@ -46,7 +49,7 @@ describe("Stockfish", () => {
     });
     const position = await anotherEngine.board();
     expect(position.Fen).toBe(STARTPOS);
-    await anotherEngine.kill();
+    anotherEngine.kill();
   });
 });
 
@@ -109,7 +112,7 @@ describe("search()", () => {
 describe("setoptions()", () => {
   it("runs", async () => {
     await engine.setoptions({
-      "Debug Log File": "/dev/null",
+      "Debug Log File": getNullDevicePath(platform),
       Contempt: -20,
       "Analysis Contempt": "Both",
       Threads: 1,

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,0 +1,15 @@
+export function getStockfishBinPath(platform: NodeJS.Platform): string {
+  if (platform === "win32") {
+    return "./stockfish/engine.exe";
+  }
+
+  return "./stockfish/engine";
+}
+
+export function getNullDevicePath(platform: NodeJS.Platform): string {
+  if (platform === "win32") {
+    return "NUL";
+  }
+
+  return "/dev/null";
+}

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,6 +1,6 @@
 export function getStockfishBinPath(platform: NodeJS.Platform): string {
   if (platform === "win32") {
-    return "./stockfish/engine.exe";
+    return "./stockfish-win/engine.exe";
   }
 
   return "./stockfish/engine";

--- a/windows-stockfish.ps1
+++ b/windows-stockfish.ps1
@@ -1,0 +1,14 @@
+# NOTE: This script has to be run in an Admin PowerShell window or else it will fail.
+# Installs Windows Stockfish 11 into ./stockfish-win and creates a symlink to the engine at ./stockfish-win/engine.exe
+
+$SF_DIR = "./stockfish-win"
+$BIN = "stockfish_20011801_x64_modern.exe"
+
+# make the directory
+New-Item -ItemType Directory -Path $SF_DIR
+# download the zip
+Invoke-WebRequest -Uri "https://stockfishchess.org/files/stockfish-11-win.zip" -OutFile "$SF_DIR/stockfish-11-win.zip"
+# unzip
+Expand-Archive -Path "$SF_DIR/stockfish-11-win.zip" -DestinationPath "$SF_DIR/."
+# symlink to the executable
+New-Item -ItemType SymbolicLink -Value "$SF_DIR/stockfish-11-win/Windows/$BIN" -Path "$SF_DIR/engine.exe" -Force


### PR DESCRIPTION
This PR adds support for tests so they pass on Windows.
Also adds a PowerShell script to the repo to download Windows Stockfish 11 into a `./stockfish-win` directory, mimicking the `linux-stockfish.sh` script.

**Note that the tests won't fully pass until PRs #13, #14 and #16 are merged first. Otherwise, some of the tests will fail.**